### PR TITLE
Ds 39

### DIFF
--- a/src/components/actions/button/Button.stories.ts
+++ b/src/components/actions/button/Button.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<typeof Button> = {
         type: 'select'
       }
     },
-    sizes: {
+    size: {
       control: {
         type: 'select'
       }

--- a/src/components/actions/button/Button.stories.ts
+++ b/src/components/actions/button/Button.stories.ts
@@ -38,13 +38,13 @@ export const Disabled: Story = {
 export const Skeleton: Story = {
   args: {
     skeleton: true,
-    className: 'h-12 w-1/6 rounded-lg'
+    className: 'h-12 w-28 rounded-lg'
   }
 }
 
 export const Loading: Story = {
   args: {
     loading: true,
-    className: 'h-12 w-1/6 rounded-lg'
+    className: 'h-12 w-28 rounded-lg'
   }
 }

--- a/src/components/actions/button/Button.stories.ts
+++ b/src/components/actions/button/Button.stories.ts
@@ -3,14 +3,59 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Button } from './Button'
 
 const meta: Meta<typeof Button> = {
-  component: Button
+  component: Button,
+  argTypes: {
+    onClick: { action: 'clicked' }
+  }
 }
 export default meta
 
 type Story = StoryObj<typeof Button>
 
-export const Basic: Story = {
+export const Primary: Story = {
   args: {
-    label: 'Basic button'
+    label: 'Button'
   }
 }
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    label: 'Disabled'
+  }
+}
+
+export const Skeleton: Story = {
+  args: {
+    skeleton: true
+  }
+}
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    label: 'Loading'
+  }
+}
+
+export const Sizes: Story = {
+  argTypes: {
+    sizes: {
+      control: {
+        type: 'select',
+        options: ['btn-xs', 'btn-sm', 'btn-md', 'btn-lg']
+      }
+    }
+  }
+}
+
+// export const Primary = Template.bind({})
+// Primary.args = {
+//   label: 'Button'
+// }
+
+// export const Disabled = Template.bind({})
+// Disabled.args = {
+//   disabled: true,
+//   label: 'Disabled'
+// }

--- a/src/components/actions/button/Button.stories.ts
+++ b/src/components/actions/button/Button.stories.ts
@@ -5,14 +5,19 @@ import { Button } from './Button'
 const meta: Meta<typeof Button> = {
   component: Button,
   argTypes: {
-    onClick: { action: 'clicked' }
+    onClick: { action: 'clicked' },
+    variant: {
+      control: {
+        type: 'select'
+      }
+    }
   }
 }
 export default meta
 
 type Story = StoryObj<typeof Button>
 
-export const Primary: Story = {
+export const Variant: Story = {
   args: {
     label: 'Button'
   }
@@ -27,35 +32,28 @@ export const Disabled: Story = {
 
 export const Skeleton: Story = {
   args: {
-    skeleton: true
+    skeleton: true,
+    className: 'h-12 w-1/6 rounded-lg'
   }
 }
 
 export const Loading: Story = {
   args: {
     loading: true,
-    label: 'Loading'
+    className: 'h-12 w-1/6 rounded-lg'
   }
 }
 
 export const Sizes: Story = {
+  args: {
+    label: 'Próxima aula'
+  },
   argTypes: {
     sizes: {
       control: {
-        type: 'select',
-        options: ['btn-xs', 'btn-sm', 'btn-md', 'btn-lg']
+        type: 'select'
       }
     }
   }
 }
 
-// export const Primary = Template.bind({})
-// Primary.args = {
-//   label: 'Button'
-// }
-
-// export const Disabled = Template.bind({})
-// Disabled.args = {
-//   disabled: true,
-//   label: 'Disabled'
-// }

--- a/src/components/actions/button/Button.stories.ts
+++ b/src/components/actions/button/Button.stories.ts
@@ -10,6 +10,11 @@ const meta: Meta<typeof Button> = {
       control: {
         type: 'select'
       }
+    },
+    sizes: {
+      control: {
+        type: 'select'
+      }
     }
   }
 }
@@ -43,17 +48,3 @@ export const Loading: Story = {
     className: 'h-12 w-1/6 rounded-lg'
   }
 }
-
-export const Sizes: Story = {
-  args: {
-    label: 'Próxima aula'
-  },
-  argTypes: {
-    sizes: {
-      control: {
-        type: 'select'
-      }
-    }
-  }
-}
-

--- a/src/components/actions/button/Button.stories.ts
+++ b/src/components/actions/button/Button.stories.ts
@@ -24,7 +24,8 @@ type Story = StoryObj<typeof Button>
 
 export const Variant: Story = {
   args: {
-    label: 'Button'
+    label: 'Button',
+    skeletonClassName: 'h-12 w-24 rounded-lg',
   }
 }
 

--- a/src/components/actions/button/Button.tsx
+++ b/src/components/actions/button/Button.tsx
@@ -1,14 +1,35 @@
-/**
- * Primary UI component for user interaction
- */
-
 interface IButton {
   label: string
+  fullWidth?: boolean
+  onClick?: () => void
+  loading?: boolean
+  className?: string
+  skeleton?: boolean
+  disabled?: boolean
+  sizes?: 'btn-xs' | 'btn-sm' | 'btn-md' | 'btn-lg'
 }
 
-export function Button({ label }: IButton) {
+export const Button: React.FC<IButton & React.HTMLProps<HTMLButtonElement>> = ({
+  label,
+  onClick,
+  loading,
+  className,
+  fullWidth,
+  disabled,
+  skeleton,
+  sizes
+}: IButton) => {
+
+  if (skeleton) {
+    return <div className={`skeleton ${fullWidth && 'w-full'} ${className}`} />
+  }
+
   return (
-    <button className="btn btn-primary uppercase text-white" type="button">
+    <button
+      className={`btn btn-primary ${fullWidth && 'w-full'} ${loading && 'loading'} uppercase ${className} ${sizes}`}
+      type="button"
+      disabled={disabled || loading}
+      onClick={onClick}>
       {label}
     </button>
   )

--- a/src/components/actions/button/Button.tsx
+++ b/src/components/actions/button/Button.tsx
@@ -3,19 +3,11 @@ interface IButton {
   fullWidth?: boolean
   className?: string
   loading?: boolean
-  sizes?: 'btn-xs' | 'btn-sm' | 'btn-md' | 'btn-lg'
   disabled?: boolean
   label?: string
   onClick?: () => void
-  variant?:
-    | 'btn-primary'
-    | 'btn-secondary'
-    | 'btn-accent'
-    | 'btn-neutral'
-    | 'btn-ghost'
-    | 'btn-link'
-    | 'btn-success'
-    | 'btn-error'
+  btnSize?: 'xs' | 'sm' | 'md' | 'lg'
+  variant?: 'primary' | 'secondary' | 'accent' | 'neutral' | 'ghost' | 'link' | 'success' | 'error'
 }
 
 export function Button({
@@ -23,17 +15,35 @@ export function Button({
   fullWidth,
   className,
   loading,
-  sizes,
+  btnSize = 'md',
   disabled,
   label,
   onClick,
-  variant = 'btn-primary'
+  variant = 'primary'
 }: IButton & React.HTMLProps<HTMLButtonElement>) {
   if (skeleton) return <div className={`skeleton ${fullWidth && 'w-full'} ${className}`} />
 
+  const btnVariant = {
+    primary: 'btn-primary text-white',
+    secondary: 'btn-secondary text-white',
+    accent: 'btn-accent text-white',
+    neutral: 'btn-neutral text-white',
+    ghost: 'btn-white text-primary',
+    link: 'text-primary',
+    success: 'btn-success text-white',
+    error: 'btn-error text-white'
+  }
+
+  const btnSizeVariant = {
+    xs: 'btn-xs',
+    sm: 'btn-sm',
+    md: 'btn-md',
+    lg: 'btn-lg'
+  }
+
   return (
     <button
-      className={`btn ${variant} ${fullWidth && 'w-full'} uppercase ${className} ${sizes}`}
+      className={`btn ${btnVariant[variant]} ${fullWidth && 'w-full'} uppercase ${className} ${btnSizeVariant[btnSize]}`}
       type="button"
       disabled={disabled || loading}
       onClick={onClick}>

--- a/src/components/actions/button/Button.tsx
+++ b/src/components/actions/button/Button.tsx
@@ -18,7 +18,7 @@ interface IButton {
     | 'btn-error'
 }
 
-export const Button: React.FC<IButton & React.HTMLProps<HTMLButtonElement>> = ({
+export function Button({
   skeleton,
   fullWidth,
   className,
@@ -28,7 +28,7 @@ export const Button: React.FC<IButton & React.HTMLProps<HTMLButtonElement>> = ({
   label,
   onClick,
   variant = 'btn-primary'
-}: IButton) => {
+}: IButton & React.HTMLProps<HTMLButtonElement>) {
   if (skeleton) return <div className={`skeleton ${fullWidth && 'w-full'} ${className}`} />
 
   return (

--- a/src/components/actions/button/Button.tsx
+++ b/src/components/actions/button/Button.tsx
@@ -2,6 +2,7 @@ interface IButton {
   skeleton?: boolean
   fullWidth?: boolean
   className?: string
+  skeletonClassName?: string
   loading?: boolean
   disabled?: boolean
   label?: string
@@ -14,6 +15,7 @@ export function Button({
   skeleton,
   fullWidth,
   className,
+  skeletonClassName,
   loading,
   btnSize = 'md',
   disabled,
@@ -21,7 +23,7 @@ export function Button({
   onClick,
   variant = 'primary'
 }: IButton & React.HTMLProps<HTMLButtonElement>) {
-  if (skeleton) return <div className={`skeleton ${fullWidth && 'w-full'} ${className}`} />
+  if (skeleton) return <div className={`skeleton h-12 w-28 rounded-md ${fullWidth && 'w-full'} ${skeletonClassName}`} />
 
   const btnVariant = {
     primary: 'btn-primary text-white',

--- a/src/components/actions/button/Button.tsx
+++ b/src/components/actions/button/Button.tsx
@@ -1,36 +1,43 @@
 interface IButton {
-  label: string
-  fullWidth?: boolean
-  onClick?: () => void
-  loading?: boolean
-  className?: string
   skeleton?: boolean
-  disabled?: boolean
+  fullWidth?: boolean
+  className?: string
+  loading?: boolean
   sizes?: 'btn-xs' | 'btn-sm' | 'btn-md' | 'btn-lg'
+  disabled?: boolean
+  label?: string
+  onClick?: () => void
+  variant?:
+    | 'btn-primary'
+    | 'btn-secondary'
+    | 'btn-accent'
+    | 'btn-neutral'
+    | 'btn-ghost'
+    | 'btn-link'
+    | 'btn-success'
+    | 'btn-error'
 }
 
 export const Button: React.FC<IButton & React.HTMLProps<HTMLButtonElement>> = ({
+  skeleton,
+  fullWidth,
+  className,
+  loading,
+  sizes,
+  disabled,
   label,
   onClick,
-  loading,
-  className,
-  fullWidth,
-  disabled,
-  skeleton,
-  sizes
+  variant = 'btn-primary'
 }: IButton) => {
-
-  if (skeleton) {
-    return <div className={`skeleton ${fullWidth && 'w-full'} ${className}`} />
-  }
+  if (skeleton) return <div className={`skeleton ${fullWidth && 'w-full'} ${className}`} />
 
   return (
     <button
-      className={`btn btn-primary ${fullWidth && 'w-full'} ${loading && 'loading'} uppercase ${className} ${sizes}`}
+      className={`btn ${variant} ${fullWidth && 'w-full'} uppercase ${className} ${sizes}`}
       type="button"
       disabled={disabled || loading}
       onClick={onClick}>
-      {label}
+      {loading ? <span className="loading loading-spinner"></span> : label}
     </button>
   )
 }


### PR DESCRIPTION
https://sejadev.atlassian.net/jira/software/c/projects/DS/boards/4?selectedIssue=DS-39


Tentei seguir o modelo do Jira, com a diferença de que adicionei uma variante. Caso seja desnecessário, é só avisar que eu removo.

O estado "skeleton" anteriormente tinha um tamanho predefinido que eu utilizei apenas para visualizar o componente dentro do Storybook, pois ele precisa de uma altura para ser exibido. Depois, percebi que posso usá-lo na história sem interferir no componente.

![Captura de tela 2024-04-09 125951](https://github.com/Seja-Dev/sejadev-ui/assets/94402903/5dc2def8-fc40-467f-8882-056b85888969)

Utilizei ele da seguinte forma dentro do componente


![Captura de tela 2024-04-09 130052](https://github.com/Seja-Dev/sejadev-ui/assets/94402903/99f3b5b9-6133-4fcf-8a0c-9da93996d74b)

Não adicionei nenhuma largura ou altura porque existe a propriedade className e o tamanho do skeleton pode ser passado através dessa prop, mas se necessário, posso adicionar uma propriedade de width e height.

O estado "Loading", quando utilizado diretamente na classe do botão (className), na visualização do Storybook, mostrava apenas o carregamento e não o botão. Ao revisar a documentação do DaisyUI, encontrei um componente button com um span onde o spinner estava inserido. Optei então por utilizar essa dessa forma.

Essas foram as props que eu usei: 

![Captura de tela 2024-04-09 130345](https://github.com/Seja-Dev/sejadev-ui/assets/94402903/b5aeaebc-9cb8-46e5-b6bf-86b1d8379273)
 
E assim ficou o componente:

![Captura de tela 2024-04-09 130434](https://github.com/Seja-Dev/sejadev-ui/assets/94402903/1820a74d-4e27-4103-bbad-02ff5871bfb1)

E o stories 

![Captura de tela 2024-04-09 175106](https://github.com/Seja-Dev/sejadev-ui/assets/94402903/e858d619-8f23-4f03-802a-c3e405ef1988)

![Captura de tela 2024-04-09 175153](https://github.com/Seja-Dev/sejadev-ui/assets/94402903/2daba0a4-8546-46fc-8986-f5a09cd564c3)
